### PR TITLE
Increase default cache time and allow customising it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ COPY cryptowat_exporter  /bin/cryptowat_exporter
 
 ENV CRYPTOWAT_EXCHANGES="bitstamp,kraken,coinbase-pro"
 ENV CRYPTOWAT_PAIRS="btcusd,ltcusd"
+ENV CRYPTOWAT_CACHESECONDS="900"
 ENV WEB_LISTEN_ADDRESS=":9745"
 
 EXPOSE      9745
-ENTRYPOINT  ./bin/cryptowat_exporter --web.listen-address $WEB_LISTEN_ADDRESS --cryptowat.exchanges $CRYPTOWAT_EXCHANGES --cryptowat.pairs $CRYPTOWAT_PAIRS
+ENTRYPOINT  ./bin/cryptowat_exporter --web.listen-address $WEB_LISTEN_ADDRESS --cryptowat.exchanges $CRYPTOWAT_EXCHANGES --cryptowat.pairs $CRYPTOWAT_PAIRS --cryptowat.cacheseconds $CRYPTOWAT_CACHESECONDS

--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ The exporter takes some command line parameters that allow configuring a few thi
 * `--cryptowat.cachesecs`: Number of seconds to cache values for (default: 60)
 * `--web.listen-address`: Address and port to listen on (default: `:9745`)
 
-Docker users can customise the list of exchanges and pairs using the following environment variables:
+Docker users can customise the list of exchanges, pairs and cache lifetime using the following environment variables:
 
 * `CRYPTOWAT_EXCHANGES`
 * `CRYPTOWAT_PAIRS`
+* `CRYPTOWAT_CACHESECONDS`
 
 See the [Dockerfile](https://github.com/nbarrientos/cryptowat_exporter/blob/master/Dockerfile) for more details.
 
@@ -101,7 +102,7 @@ scrape_configs:
       - targets: ['localhost:9745']
 ```
 
-You can poll as often as you want but, by default, the exporter only refreshes the cached values every minute. This can be changed using `--cryptowat.cachesecs` but bear in mind that Cryptowat.ch's API does rate limiting.
+You can poll as often as you want but, by default, the exporter only refreshes the cached values every fifteen minutes. This can be changed using `--cryptowat.cachesecs` but bear in mind that Cryptowat.ch's API does rate limiting.
 
 ## Example Grafana visualisations
 

--- a/main.go
+++ b/main.go
@@ -140,7 +140,7 @@ func main() {
 		listenAddress = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9745").String()
 		exchanges     = kingpin.Flag("cryptowat.exchanges", "Comma separated list of exchanges.").Default("kraken,bitstamp").String()
 		pairs         = kingpin.Flag("cryptowat.pairs", "Comma separated list of pairs.").Default("btcusd,ltcusd").String()
-		cacheSeconds  = kingpin.Flag("cryptowat.cacheseconds", "Number of seconds to cache values for.").Default("60").String()
+		cacheSeconds  = kingpin.Flag("cryptowat.cacheseconds", "Number of seconds to cache values for.").Default("900").String()
 	)
 	kingpin.Parse()
 


### PR DESCRIPTION
It looks like it's more expensive now to query the API so the default cache time is not enough to cope with a 24h operation. This change increases the default from 60 seconds to 900 and allows Docker user to customise it via environment variables.